### PR TITLE
fix: resets interval timer on control click

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -354,7 +354,7 @@
 
     // (6:1) {#if controls}
     function create_if_block_1(ctx) {
-    	var button0, t, button1, current, dispose;
+    	var button0, resetInterval_action, t, button1, resetInterval_action_1, current, dispose;
 
     	const left_control_slot_1 = ctx.$$slots["left-control"];
     	const left_control_slot = create_slot(left_control_slot_1, ctx, get_left_control_slot_context);
@@ -397,6 +397,7 @@
     				left_control_slot.m(button0, null);
     			}
 
+    			resetInterval_action = ctx.resetInterval.call(null, button0, ctx.autoplay) || {};
     			insert(target, t, anchor);
     			insert(target, button1, anchor);
 
@@ -404,6 +405,7 @@
     				right_control_slot.m(button1, null);
     			}
 
+    			resetInterval_action_1 = ctx.resetInterval.call(null, button1, ctx.autoplay) || {};
     			current = true;
     		},
 
@@ -412,8 +414,16 @@
     				left_control_slot.p(get_slot_changes(left_control_slot_1, ctx, changed, get_left_control_slot_changes), get_slot_context(left_control_slot_1, ctx, get_left_control_slot_context));
     			}
 
+    			if (typeof resetInterval_action.update === 'function' && changed.autoplay) {
+    				resetInterval_action.update.call(null, ctx.autoplay);
+    			}
+
     			if (right_control_slot && right_control_slot.p && changed.$$scope) {
     				right_control_slot.p(get_slot_changes(right_control_slot_1, ctx, changed, get_right_control_slot_changes), get_slot_context(right_control_slot_1, ctx, get_right_control_slot_context));
+    			}
+
+    			if (typeof resetInterval_action_1.update === 'function' && changed.autoplay) {
+    				resetInterval_action_1.update.call(null, ctx.autoplay);
     			}
     		},
 
@@ -436,6 +446,7 @@
     			}
 
     			if (left_control_slot) left_control_slot.d(detaching);
+    			if (resetInterval_action && typeof resetInterval_action.destroy === 'function') resetInterval_action.destroy();
 
     			if (detaching) {
     				detach(t);
@@ -443,6 +454,7 @@
     			}
 
     			if (right_control_slot) right_control_slot.d(detaching);
+    			if (resetInterval_action_1 && typeof resetInterval_action_1.destroy === 'function') resetInterval_action_1.destroy();
     			run_all(dispose);
     		}
     	};
@@ -731,7 +743,24 @@
     			currentSlide: controller.currentSlide,
     			slideCount: controller.innerElements.length
     		} );
-    	}
+      }
+      
+      function resetInterval(node, condition) {
+    		function handleReset(event) {
+    			pause();
+    			resume();
+    		}
+    		
+    		if(condition) {
+    			node.addEventListener('click', handleReset);
+    		}
+    		
+    		return {
+    		    destroy() {
+    			    node.removeEventListener('click', handleReset);
+    		    }
+    	    }
+      }
 
     	let { $$slots = {}, $$scope } = $$props;
 
@@ -789,6 +818,7 @@
     		go,
     		pause,
     		resume,
+    		resetInterval,
     		currentPerPage,
     		totalDots,
     		div0_binding,

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -348,7 +348,7 @@ const get_left_control_slot_context = ({}) => ({});
 
 // (6:1) {#if controls}
 function create_if_block_1(ctx) {
-	var button0, t, button1, current, dispose;
+	var button0, resetInterval_action, t, button1, resetInterval_action_1, current, dispose;
 
 	const left_control_slot_1 = ctx.$$slots["left-control"];
 	const left_control_slot = create_slot(left_control_slot_1, ctx, get_left_control_slot_context);
@@ -391,6 +391,7 @@ function create_if_block_1(ctx) {
 				left_control_slot.m(button0, null);
 			}
 
+			resetInterval_action = ctx.resetInterval.call(null, button0, ctx.autoplay) || {};
 			insert(target, t, anchor);
 			insert(target, button1, anchor);
 
@@ -398,6 +399,7 @@ function create_if_block_1(ctx) {
 				right_control_slot.m(button1, null);
 			}
 
+			resetInterval_action_1 = ctx.resetInterval.call(null, button1, ctx.autoplay) || {};
 			current = true;
 		},
 
@@ -406,8 +408,16 @@ function create_if_block_1(ctx) {
 				left_control_slot.p(get_slot_changes(left_control_slot_1, ctx, changed, get_left_control_slot_changes), get_slot_context(left_control_slot_1, ctx, get_left_control_slot_context));
 			}
 
+			if (typeof resetInterval_action.update === 'function' && changed.autoplay) {
+				resetInterval_action.update.call(null, ctx.autoplay);
+			}
+
 			if (right_control_slot && right_control_slot.p && changed.$$scope) {
 				right_control_slot.p(get_slot_changes(right_control_slot_1, ctx, changed, get_right_control_slot_changes), get_slot_context(right_control_slot_1, ctx, get_right_control_slot_context));
+			}
+
+			if (typeof resetInterval_action_1.update === 'function' && changed.autoplay) {
+				resetInterval_action_1.update.call(null, ctx.autoplay);
 			}
 		},
 
@@ -430,6 +440,7 @@ function create_if_block_1(ctx) {
 			}
 
 			if (left_control_slot) left_control_slot.d(detaching);
+			if (resetInterval_action && typeof resetInterval_action.destroy === 'function') resetInterval_action.destroy();
 
 			if (detaching) {
 				detach(t);
@@ -437,6 +448,7 @@ function create_if_block_1(ctx) {
 			}
 
 			if (right_control_slot) right_control_slot.d(detaching);
+			if (resetInterval_action_1 && typeof resetInterval_action_1.destroy === 'function') resetInterval_action_1.destroy();
 			run_all(dispose);
 		}
 	};
@@ -725,7 +737,24 @@ function instance($$self, $$props, $$invalidate) {
 			currentSlide: controller.currentSlide,
 			slideCount: controller.innerElements.length
 		} );
-	}
+  }
+  
+  function resetInterval(node, condition) {
+		function handleReset(event) {
+			pause();
+			resume();
+		}
+		
+		if(condition) {
+			node.addEventListener('click', handleReset);
+		}
+		
+		return {
+		    destroy() {
+			    node.removeEventListener('click', handleReset);
+		    }
+	    }
+  }
 
 	let { $$slots = {}, $$scope } = $$props;
 
@@ -783,6 +812,7 @@ function instance($$self, $$props, $$invalidate) {
 		go,
 		pause,
 		resume,
+		resetInterval,
 		currentPerPage,
 		totalDots,
 		div0_binding,

--- a/src/Carousel.svelte
+++ b/src/Carousel.svelte
@@ -4,10 +4,10 @@
 		<slot></slot>
 	</div>
 	{#if controls}
-	<button class="left" on:click={left} aria-label="left">
+	<button class="left" on:click={left} use:resetInterval={autoplay} aria-label="left">
 		<slot name="left-control"></slot>
 	</button>
-	<button class="right" on:click={right} aria-label="right">
+	<button class="right" on:click={right} use:resetInterval={autoplay} aria-label="right">
 		<slot name="right-control"></slot>
 	</button>
 	{/if}
@@ -165,5 +165,22 @@
 			currentSlide: controller.currentSlide,
 			slideCount: controller.innerElements.length
 		} )
-	}
+  }
+  
+  function resetInterval(node, condition) {
+		function handleReset(event) {
+			pause();
+			resume();
+		}
+		
+		if(condition) {
+			node.addEventListener('click', handleReset);
+		}
+		
+		return {
+		    destroy() {
+			    node.removeEventListener('click', handleReset);
+		    }
+	    }
+  }
 </script>


### PR DESCRIPTION
This fixes the second half of #45. I set it up as an action:

```
<button class="left" on:click={left} use:resetInterval={autoplay} aria-label="left">

...

function resetInterval(node, condition) {
    function handleReset(event) {
        pause();
        resume();
    }

    if(condition) {
        node.addEventListener('click', handleReset);
    }

    return {
        destroy() {
            node.removeEventListener('click', handleReset);
        }
    }
}

```

REPL Example: https://svelte.dev/repl/a363db348ba4485d965c5b5464428a73?version=3.31.2

I didn't try implementing the first part of the issue (pause on hover) because I noticed that it was a part of the API and I wasn't sure if you wanted it to remain that way or if you'd rather it become a standard feature. If you *did* want that change I'd be happy to submit another PR for it.

Since this is an "under-the-hood" fix I didn't edit anything in the README. Let me know if anything is off! Thanks!

