### PR TITLE
Fix error if calling `resume` method when carousel is already playing

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -693,6 +693,7 @@
 
     		return () => {
     			autoplay && clearInterval(timer);
+    			timer = null;
     			controller.destroy();
     		}
     	});
@@ -716,10 +717,11 @@
     	
     	function pause() {
     		clearInterval(timer);
+    		timer = null;
     	}
 
     	function resume() {
-    		if (autoplay) {
+    		if (autoplay && !timer) {
     			timer = setInterval(right, autoplay);
     		}
     	}

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -687,6 +687,7 @@ function instance($$self, $$props, $$invalidate) {
 
 		return () => {
 			autoplay && clearInterval(timer);
+			timer = null;
 			controller.destroy();
 		}
 	});
@@ -710,10 +711,11 @@ function instance($$self, $$props, $$invalidate) {
 	
 	function pause() {
 		clearInterval(timer);
+		timer = null;
 	}
 
 	function resume() {
-		if (autoplay) {
+		if (autoplay && !timer) {
 			timer = setInterval(right, autoplay);
 		}
 	}

--- a/src/Carousel.svelte
+++ b/src/Carousel.svelte
@@ -127,6 +127,7 @@
 
 		return () => {
 			autoplay && clearInterval(timer)
+			timer = null
 			controller.destroy()
 		}
 	})
@@ -150,10 +151,11 @@
 	
 	export function pause() {
 		clearInterval(timer);
+		timer = null
 	}
 
 	export function resume() {
-		if (autoplay) {
+		if (autoplay && !timer) {
 			timer = setInterval(right, autoplay);
 		}
 	}


### PR DESCRIPTION
# Bug description

When the component moves automatically via `autoplay` prop, there is the possibility to play/pause that movement via JavaScript with `carouselRef.pause()` and `carouselRef.resume()` methods. 

If `resume` is called when the carousel is already playing, the component moves by 2 slides instead of just one. If the method gets called again, the movement increases to three slides each time.

Here is an example of it: https://svelte.dev/repl/f4e6f8863c3c47f4b64aa2ba9f32795d?version=3.32.0

Ideally, a call to `resume` when the component is already auto-playing should have no effect at all.

# Technical fix

The current implementation of `resume` just adds and additional interval as long as `autoplay` prop is passed:
```
if (autoplay) {
  timer = setInterval(right, autoplay);
}
```

This PR just extends that condition to avoid adding a new interval if there is already one active.